### PR TITLE
Use macos-15 to more closely resemble CRAN's machine

### DIFF
--- a/run-check/scripts/mac-asan.sh
+++ b/run-check/scripts/mac-asan.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 
-# Use XCode 16.2 ------------------------------------------------
+# Use XCode 16.3 ------------------------------------------------
 sudo rm -f /Applications/Xcode.app
-sudo ln -sfF /Applications/Xcode_16.2.app /Applications/Xcode.app
+sudo ln -sfF /Applications/Xcode_16.3.app /Applications/Xcode.app
 sudo xcode-select -s /Applications/Xcode.app
 
 # Compile with sanitizers ---------------------------------------
@@ -24,7 +24,7 @@ R=$(readlink `which R`)
 head -1 ${R} >> /tmp/R
 cat >> /tmp/R <<EOF
 export DYLD_FORCE_FLAT_NAMESPACE=1
-export DYLD_INSERT_LIBRARIES=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/16/lib/darwin/libclang_rt.asan_osx_dynamic.dylib
+export DYLD_INSERT_LIBRARIES=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/lib/darwin/libclang_rt.asan_osx_dynamic.dylib
 EOF
 cat ${R} >> /tmp/R
 chmod +x /tmp/R

--- a/setup/platforms.json
+++ b/setup/platforms.json
@@ -294,7 +294,7 @@
         "aliases": [],
         "type": "os",
         "os-type": "macOS",
-        "os": "macos-latest",
+        "os": "macos-15",
         "arch": "arm64",
         "r-version": "*",
         "pre-check": ["mac-asan.sh"]


### PR DESCRIPTION
Noticed when diagnosing https://github.com/apache/arrow/pull/46124 macos14 / clang16 doesn't actually catch the issue we had. 

I had to set my action up with macos15 + clang17 in order for it to work:
[GHA with macos 15](https://github.com/jonkeane/simple-package/blob/efb023089ac2a0ac91427b18b039f2066e5cd51d/.github/workflows/m1-san.yaml) and [github action — failing](https://github.com/jonkeane/simple-package/actions/runs/14469441634/job/40579406438)
[GHA with macos 14](https://github.com/jonkeane/simple-package/blob/a80793b934e1a8f6cab64e63263eafa855b606d4/.github/workflows/m1-san.yaml) and [github action — passing](https://github.com/jonkeane/simple-package/actions/runs/14471951591/job/40587938308)
