### PR TITLE
Action to register Redhat key

### DIFF
--- a/register-redhat/README.md
+++ b/register-redhat/README.md
@@ -1,0 +1,12 @@
+# Register Redhat system
+
+Simple wrapper for the Redhat `subscription-manager` command to automatically unregister the key in a post step. 
+
+Example usage:
+
+```yaml
+      - uses: r-hub/actions/register-redhat@v1
+        env:
+          REDHAT_ORG: ${{ secrets.REDHAT_ORG }}
+          REDHAT_KEY: ${{ secrets.REDHAT_KEY }}
+```

--- a/register-redhat/action.yml
+++ b/register-redhat/action.yml
@@ -1,0 +1,8 @@
+name: Register a RHEL system
+
+description: 'Register and automatically unregister Redhat activation keys'
+
+runs:
+  using: 'node20'
+  main: 'main.js'
+  post: 'post.js'

--- a/register-redhat/main.js
+++ b/register-redhat/main.js
@@ -1,0 +1,11 @@
+const { spawn } = require("child_process");
+const org = process.env.REDHAT_ORG;
+const key = process.env.REDHAT_KEY;
+if(!org || !key){
+   throw "Need to set REDHAT_ORG and REDHAT_KEY environment variables";
+}
+const cmd = `subscription-manager register --org ${org} --activationkey ${key}`;
+const subprocess = spawn(cmd, { stdio: "inherit", shell: true });
+subprocess.on("exit", (exitCode) => {
+  process.exitCode = exitCode;
+});

--- a/register-redhat/post.js
+++ b/register-redhat/post.js
@@ -1,0 +1,6 @@
+const { spawn } = require("child_process");
+const cmd = 'subscription-manager unregister || true';
+const subprocess = spawn(cmd, { stdio: "inherit", shell: true });
+subprocess.on("exit", (exitCode) => {
+  process.exitCode = exitCode;
+});


### PR DESCRIPTION
Simple wrapper for the Redhat `subscription-manager` command to automatically unregister the key in a post step. 

This unregisters the key in the `post` step, even when `R CMD check` hangs.

Example usage:

```yaml
      - uses: r-hub/actions/register-redhat@v1
        env:
          REDHAT_ORG: ${{ secrets.REDHAT_ORG }}
          REDHAT_KEY: ${{ secrets.REDHAT_KEY }}
```