### PR TITLE
Better run-name for workflow dispatch; add URL hint for containers

### DIFF
--- a/workflows/rhub.yaml
+++ b/workflows/rhub.yaml
@@ -7,20 +7,24 @@
 # It is unlikely that you need to modify this file manually.
 
 name: R-hub
-run-name: "${{ github.event.inputs.id }}: ${{ github.event.inputs.name || format('Manually run by {0}', github.triggering_actor) }}"
+run-name: >-
+  ${{ github.event.inputs.id || format('Manual run by @{0}', github.triggering_actor) }}:
+  ${{ github.event.inputs.name || github.event.inputs.config }}
 
 on:
   workflow_dispatch:
     inputs:
       config:
-        description: 'A comma separated list of R-hub platforms to use.'
+        description: >-
+          Comma-separated list of R-hub platforms to use.
+          Full list: https://r-hub.github.io/containers/
         type: string
         default: 'linux,windows,macos'
       name:
-        description: 'Run name. You can leave this empty now.'
+        description: 'Run name. You can leave this empty.'
         type: string
       id:
-        description: 'Unique ID. You can leave this empty now.'
+        description: 'Unique ID. You can leave this empty.'
         type: string
 
 jobs:


### PR DESCRIPTION
This is a small quality-of-life PR. I mostly run r-hub in CI via workflow dispatch and the default workflow yields a run name with a mysterious leading colon and doesn't reveal the container(s) used:

<img width="260" height="87" alt="Screenshot 2026-05-04 at 5 04 29 PM" src="https://github.com/user-attachments/assets/d04e1d94-d19a-488f-9c1d-089446ae26af" />

This PR levels up workflow dispatch to be closer to the result when using `rhub::rhub::check()` and makes a few other tweaks

* Always populate both sides of the colon
  <img width="435" height="161" alt="Screenshot 2026-05-04 at 4 51 42 PM" src="https://github.com/user-attachments/assets/f212330e-8543-4db1-ae2e-c7f54c1da0ce" />
* Give a URL hint where folks can see the full list of container choices (I've confirmed this is copy/paste-able)
* Remove mysterious "now" re: run name and unique ID
  <img width="275" height="237" alt="Screenshot 2026-05-04 at 5 08 23 PM" src="https://github.com/user-attachments/assets/2e5899de-fb82-4fb6-b089-76417548819d" />
