### PR TITLE
Install quarto where it is required to check packages

### DIFF
--- a/workflows/rhub.yaml
+++ b/workflows/rhub.yaml
@@ -64,6 +64,9 @@ jobs:
         with:
           token: ${{ secrets.RHUB_TOKEN }}
           job-config: ${{ matrix.config.job-config }}
+      - uses: ms609/actions/rhub-quarto@main
+        with:
+          linux: 'true'
       - uses: r-hub/actions/run-check@v1
         with:
           token: ${{ secrets.RHUB_TOKEN }}
@@ -93,6 +96,9 @@ jobs:
         with:
           job-config: ${{ matrix.config.job-config }}
           token: ${{ secrets.RHUB_TOKEN }}
+      - uses: ms609/actions/rhub-quarto@main
+        with:
+          linux: 'false'
       - uses: r-hub/actions/run-check@v1
         with:
           job-config: ${{ matrix.config.job-config }}

--- a/workflows/rhub.yaml
+++ b/workflows/rhub.yaml
@@ -66,6 +66,7 @@ jobs:
           job-config: ${{ matrix.config.job-config }}
       - uses: ms609/actions/rhub-quarto@main
         with:
+          token: ${{ secrets.RHUB_TOKEN }}
           linux: 'true'
       - uses: r-hub/actions/run-check@v1
         with:
@@ -98,6 +99,7 @@ jobs:
           token: ${{ secrets.RHUB_TOKEN }}
       - uses: ms609/actions/rhub-quarto@main
         with:
+          token: ${{ secrets.RHUB_TOKEN }}
           linux: 'false'
       - uses: r-hub/actions/run-check@v1
         with:


### PR DESCRIPTION
Closes https://github.com/r-hub/rhub/issues/681.

Where an R package uses quarto to build vignettes, R-hub runs currently fail due to the absence of a quarto installation.

I've created a [template](https://github.com/ms609/actions/blob/main/rhub-quarto/action.yml) that:

- Checks `DESCRIPTION` for `VignetteBuilder: quarto`
- If quarto is required:
  - Detects the operating system of the container
  - Installs quarto
  - Pre-installs the package so it's available for the vignette checks.

I've successfully [tested](https://github.com/ms609/Coreset/actions/runs/34596707990) the template against one of my own packages.

I'm open to the template repository being moved to `r-hub` from my personal repository if that'd be deemed more appropriate.